### PR TITLE
ILogger in Consent should be for that class

### DIFF
--- a/Pages/Ciba/Consent.cshtml.cs
+++ b/Pages/Ciba/Consent.cshtml.cs
@@ -15,12 +15,12 @@ public class Consent : PageModel
 {
     private readonly IBackchannelAuthenticationInteractionService _interaction;
     private readonly IEventService _events;
-    private readonly ILogger<Index> _logger;
+    private readonly ILogger<Consent> _logger;
 
     public Consent(
         IBackchannelAuthenticationInteractionService interaction,
         IEventService events,
-        ILogger<Index> logger)
+        ILogger<Consent> logger)
     {
         _interaction = interaction;
         _events = events;


### PR DESCRIPTION
It seems like the `ILogger<T>` should be for `Consent` not `Index`